### PR TITLE
implement `addBuildChecks` overlay helper

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -307,7 +307,7 @@
         };
       };
 
-    defExternalCheck = name: package: exec: self: super: {
+    addShellCheck = name: package: exec: self: super: {
       toFlake =
         let
           inherit (self) inputs perSystem pkgsFor';
@@ -353,7 +353,7 @@
       let
         extStr = builtins.concatStringsSep " " (builtins.map (x: "-o " + x) exts);
       in
-      defExternalCheck "formatCheck" (p: self.fourmoluFor p) ''
+      addShellCheck "formatCheck" (p: self.fourmoluFor p) ''
         find -name '*.hs' \
           -not -path './dist*/*' \
           -not -path './haddock/*' \
@@ -363,19 +363,19 @@
 
     # Enables running hlint on `*.hs` files.
     enableLintCheck =
-      defExternalCheck "lintCheck" (p: [ p.hlint ]) ''
+      addShellCheck "lintCheck" (p: [ p.hlint ]) ''
         find -name '*.hs' -not -path './dist*/*' -not -path './haddock/*' | xargs hlint 
       '';
 
     # Enables running cabal-fmt on `*.cabal` files.
     enableCabalFormatCheck =
-      defExternalCheck "cabalFormatCheck" (p: [ p.haskellPackages.cabal-fmt ]) ''
+      addShellCheck "cabalFormatCheck" (p: [ p.haskellPackages.cabal-fmt ]) ''
         find -name '*.cabal' -not -path './dist*/*' -not -path './haddock/*' | xargs cabal-fmt -c
       '';
 
     # Enables running nixpkgs-fmt on `*.nix` files.
     enableNixFormatCheck =
-      defExternalCheck "nixFormatCheck" (p: [ p.nixpkgs-fmt ]) ''
+      addShellCheck "nixFormatCheck" (p: [ p.nixpkgs-fmt ]) ''
         find -name '*.nix' -not -path './dist*/*' -not -path './haddock/*' | xargs nixpkgs-fmt --check
       '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -38,9 +38,12 @@
     # - 'toFlake' is expected to be what the flake will eventually resolve to
     #
     # Other attribute conventions may happen as result of using overlays.
-    buildProject = args@{ inputs
+    buildProject =
+      args@{ inputs
       , supportedSystems ? inputs.nixpkgs-latest.lib.systems.flakeExposed
-      , ghcVersion ? "ghc923", ... }:
+      , ghcVersion ? "ghc923"
+      , ...
+      }:
       overlays:
       let
         base = {
@@ -77,8 +80,9 @@
         # https://blog.layus.be/posts/2020-06-12-nix-overlays.html
         resolved =
           builtins.foldl' (super: overlay: super // overlay resolved super) base
-          (baseOverlays ++ overlays);
-      in resolved;
+            (baseOverlays ++ overlays);
+      in
+      resolved;
 
     # Haskell project overlay.
     # 
@@ -95,7 +99,8 @@
       let
         inherit (self)
           inputs nixpkgs nixpkgs-latest haskell-nix pkgsFor pkgsFor';
-      in {
+      in
+      {
         fourmoluFor = pkgs:
           pkgs.haskell.packages.${self.ghcVersion}.fourmolu_0_6_0_0;
 
@@ -147,7 +152,8 @@
 
         customHackages = system: compiler-nix-name:
           inputs.haskell-nix-extra-hackage.mkHackagesFor system
-          compiler-nix-name self.hackageDeps;
+            compiler-nix-name
+            self.hackageDeps;
 
         haskellModules = super.haskellModules or [ ];
 
@@ -155,11 +161,12 @@
           let
             h = self.customHackages pkgs.system o.compiler-nix-name;
             o' = (super.applyDep or (p: o: o)) pkgs o;
-          in o' // rec {
+          in
+          o' // rec {
             modules = self.haskellModules ++ h.modules ++ (o.modules or [ ]);
             extra-hackages = h.extra-hackages ++ (o.extra-hackages or [ ]);
             extra-hackage-tarballs = h.extra-hackage-tarballs
-              // (o.extra-hackage-tarballs or { });
+            // (o.extra-hackage-tarballs or { });
             cabalProjectLocal = o'.cabalProjectLocal or "";
           };
 
@@ -168,7 +175,7 @@
           (import "${inputs.iohk-nix}/overlays/crypto")
         ];
 
-        nixpkgsStableFor = system: import inputs.nixpkgs-2205 {inherit system;};
+        nixpkgsStableFor = system: import inputs.nixpkgs-2205 { inherit system; };
 
         hlsFor' = compiler-nix-name: pkgs:
           pkgs.haskell-nix.cabalProject' {
@@ -185,10 +192,12 @@
           let
             pkgs = pkgsFor system;
             oldGhc = "8107";
-          in if (compiler-nix-name == "ghc${oldGhc}") then
-            pkgs.haskell-language-server.override {
-              supportedGhcVersions = [ oldGhc ];
-            }
+          in
+          if (compiler-nix-name == "ghc${oldGhc}") then
+            pkgs.haskell-language-server.override
+              {
+                supportedGhcVersions = [ oldGhc ];
+              }
           else
             (self.hlsFor' compiler-nix-name
               pkgs).hsPkgs.haskell-language-server.components.exes.haskell-language-server;
@@ -200,7 +209,8 @@
             haskellPackages922 = (self.nixpkgsStableFor system).haskell.packages.ghc922;
             haskellPackages923 = pkgs'.haskell.packages.ghc923;
             sup = super.commandLineTools or (system: [ ]);
-          in (sup system) ++ [
+          in
+          (sup system) ++ [
             pkgs'.cabal-install
             haskellPackages923.hlint
             pkgs'.haskellPackages.cabal-fmt
@@ -226,30 +236,34 @@
                 nativeBuildInputs = self.commandLineTools system;
               };
             });
-          in pkgSet;
+          in
+          pkgSet;
 
         projectFor = self.projectForGhc self.ghcVersion;
 
-        toFlake = let inherit (self) perSystem projectFor;
-        in (super.toFlake or { }) // {
-          project = perSystem projectFor;
+        toFlake =
+          let inherit (self) perSystem projectFor;
+          in
+          (super.toFlake or { }) // {
+            project = perSystem projectFor;
 
-          flake = perSystem (system: (projectFor system).flake { });
+            flake = perSystem (system: (projectFor system).flake { });
 
-          packages =
-            perSystem (system: self.toFlake.flake.${system}.packages // { });
+            packages =
+              perSystem (system: self.toFlake.flake.${system}.packages // { });
 
-          checks = perSystem (system: self.toFlake.flake.${system}.checks);
+            checks = perSystem (system: self.toFlake.flake.${system}.checks);
 
-          check = perSystem (system:
-            (pkgsFor system).runCommand "combined-test" {
-              checksss = builtins.attrValues self.toFlake.checks.${system};
-            } ''
-              echo $checksss
-              touch $out
-            '');
-          devShell = perSystem (system: self.toFlake.flake.${system}.devShell);
-        };
+            check = perSystem (system:
+              (pkgsFor system).runCommand "combined-test"
+                {
+                  checksss = builtins.attrValues self.toFlake.checks.${system};
+                } ''
+                echo $checksss
+                touch $out
+              '');
+            devShell = perSystem (system: self.toFlake.flake.${system}.devShell);
+          };
       };
 
     addCommandLineTools = addF: self: super: {
@@ -258,7 +272,8 @@
           pkgs = self.pkgsFor system;
           pkgs' = self.pkgsFor' system;
           sup = super.commandLineTools or (_: [ ]);
-        in (sup system) ++ (addF pkgs pkgs');
+        in
+        (sup system) ++ (addF pkgs pkgs');
     };
 
     # Add input-based dependencies to hackage deps
@@ -268,38 +283,55 @@
 
     # Define tests for Haskell project.
     addChecks = checks: self: super: {
-      toFlake = let
-        inherit (self) perSystem;
-        flake = super.toFlake or { };
-        c = system:
-          builtins.mapAttrs
-          (name: value: self.toFlake.flake.${system}.packages.${value}) checks;
-      in flake // {
-        checks = perSystem (system: flake.checks.${system} // c system);
-      };
+      toFlake =
+        let
+          inherit (self) perSystem;
+          flake = super.toFlake or { };
+          c = system:
+            builtins.mapAttrs
+              (name: value: self.toFlake.flake.${system}.packages.${value})
+              checks;
+        in
+        flake // {
+          checks = perSystem (system: flake.checks.${system} // c system);
+        };
     };
 
-    defExternalCheck = name: package: exec: self: super: {
-      toFlake = let
-        inherit (self) inputs perSystem pkgsFor';
-        flake = super.toFlake or { };          
-      in flake // {
-        checks = perSystem (system:
-          flake.checks.${system} // {
-            ${name} =
-              let pkgs' = pkgsFor' system;
-              in pkgs'.runCommand name {
-                nativeBuildInputs = [ (package pkgs') ];
-              } ''
-                   export LC_CTYPE=C.UTF-8
-                   export LC_ALL=C.UTF-8
-                   export LANG=C.UTF-8
-                   cd ${inputs.self}
-                   ${exec}
-                   mkdir $out
-              '';              
-          });
+    # Add all packages to checks, as a result, running `nix build .#check.${system}`
+    # will be a superset of `nix build`.
+    addBuildChecks = self: super:
+      let flake = (super.toFlake or { }); in
+      {
+        toFlake = flake // {
+          checks = self.perSystem (system: flake.checks.${system} // flake.packages.${system});
+        };
       };
+
+    defExternalCheck = name: package: exec: self: super: {
+      toFlake =
+        let
+          inherit (self) inputs perSystem pkgsFor';
+          flake = super.toFlake or { };
+        in
+        flake // {
+          checks = perSystem (system:
+            flake.checks.${system} // {
+              ${name} =
+                let pkgs' = pkgsFor' system;
+                in
+                pkgs'.runCommand name
+                  {
+                    nativeBuildInputs = [ (package pkgs') ];
+                  } ''
+                  export LC_CTYPE=C.UTF-8
+                  export LC_ALL=C.UTF-8
+                  export LANG=C.UTF-8
+                  cd ${inputs.self}
+                  ${exec}
+                  mkdir $out
+                '';
+            });
+        };
     };
 
 
@@ -321,38 +353,39 @@
       let
         extStr = builtins.concatStringsSep " " (builtins.map (x: "-o " + x) exts);
       in
-        defExternalCheck "formatCheck" (p: self.fourmoluFor p) ''
-          find -name '*.hs' \
-            -not -path './dist*/*' \
-            -not -path './haddock/*' \
-            | xargs fourmolu ${extStr} -m check
-        ''
+      defExternalCheck "formatCheck" (p: self.fourmoluFor p) ''
+        find -name '*.hs' \
+          -not -path './dist*/*' \
+          -not -path './haddock/*' \
+          | xargs fourmolu ${extStr} -m check
+      ''
         self;
 
     # Enables running hlint on `*.hs` files.
     enableLintCheck =
       defExternalCheck "lintCheck" (p: [ p.hlint ]) ''
-          find -name '*.hs' -not -path './dist*/*' -not -path './haddock/*' | xargs hlint 
+        find -name '*.hs' -not -path './dist*/*' -not -path './haddock/*' | xargs hlint 
       '';
 
     # Enables running cabal-fmt on `*.cabal` files.
     enableCabalFormatCheck =
       defExternalCheck "cabalFormatCheck" (p: [ p.haskellPackages.cabal-fmt ]) ''
-          find -name '*.cabal' -not -path './dist*/*' -not -path './haddock/*' | xargs cabal-fmt -c
+        find -name '*.cabal' -not -path './dist*/*' -not -path './haddock/*' | xargs cabal-fmt -c
       '';
 
     # Enables running nixpkgs-fmt on `*.nix` files.
     enableNixFormatCheck =
       defExternalCheck "nixFormatCheck" (p: [ p.nixpkgs-fmt ]) ''
-          find -name '*.nix' -not -path './dist*/*' -not -path './haddock/*' | xargs nixpkgs-fmt --check
-      '';      
+        find -name '*.nix' -not -path './dist*/*' -not -path './haddock/*' | xargs nixpkgs-fmt --check
+      '';
 
     # Plutarch project overlay.
     plutarchProject = self: super:
       let
         inherit (self) inputs pkgsFor pkgsFor';
         inherit (inputs) nixpkgs nixpkgs-latest haskell-nix plutarch;
-      in {
+      in
+      {
         haskellModules = (super.haskellModules or [ ]) ++ [
           ({ config, pkgs, hsPkgs, ... }: {
             inherit (self)
@@ -381,192 +414,195 @@
           let
             h = self.customHackages pkgs.system o.compiler-nix-name;
             o' = (super.applyDep or (p: o: o)) pkgs o;
-          in o' // rec {
+          in
+          o' // rec {
             modules = self.haskellModules ++ h.modules ++ (o.modules or [ ]);
             extra-hackages = h.extra-hackages ++ (o.extra-hackages or [ ]);
             extra-hackage-tarballs = h.extra-hackage-tarballs
-              // (o.extra-hackage-tarballs or { });
-            cabalProjectLocal = o'.cabalProjectLocal or "" + (''
-              allow-newer:
-                cardano-binary:base
-                , cardano-crypto-class:base
-                , cardano-prelude:base
-                , canonical-json:bytestring
-                , plutus-core:ral
-                , plutus-core:some
-                , int-cast:base
-                , inline-r:singletons
-              constraints:
-                OneTuple >= 0.3.1
-                , Only >= 0.1
-                , QuickCheck >= 2.14.2
-                , StateVar >= 1.2.2
-                , Stream >= 0.4.7.2
-                , adjunctions >= 4.4
-                , aeson >= 2.0.3.0
-                , algebraic-graphs >= 0.6
-                , ansi-terminal >= 0.11.1
-                , ansi-wl-pprint >= 0.6.9
-                , assoc >= 1.0.2
-                , async >= 2.2.4
-                , attoparsec >= 0.14.4
-                , barbies >= 2.0.3.1
-                , base-compat >= 0.12.1
-                , base-compat-batteries >= 0.12.1
-                , base-orphans >= 0.8.6
-                , base16-bytestring >= 1.0.2.0
-                , basement >= 0.0.12
-                , bifunctors >= 5.5.11
-                , bimap >= 0.4.0
-                , bin >= 0.1.2
-                , boring >= 0.2
-                , boxes >= 0.1.5
-                , cabal-doctest >= 1.0.9
-                , call-stack >= 0.4.0
-                , canonical-json >= 0.6.0.0
-                , cardano-binary >= 1.5.0
-                , cardano-crypto >= 1.1.0
-                , cardano-crypto-class >= 2.0.0
-                , cardano-prelude >= 0.1.0.0
-                , case-insensitive >= 1.2.1.0
-                , cassava >= 0.5.2.0
-                , cborg >= 0.2.6.0
-                , clock >= 0.8.2
-                , colour >= 2.3.6
-                , comonad >= 5.0.8
-                , composition-prelude >= 3.0.0.2
-                , concurrent-output >= 1.10.14
-                , constraints >= 0.13.2
-                , constraints-extras >= 0.3.2.1
-                , contravariant >= 1.5.5
-                , cryptonite >= 0.29
-                , data-default >= 0.7.1.1
-                , data-default-class >= 0.1.2.0
-                , data-default-instances-containers >= 0.0.1
-                , data-default-instances-dlist >= 0.0.1
-                , data-default-instances-old-locale >= 0.0.1
-                , data-fix >= 0.3.2
-                , dec >= 0.0.4
-                , dependent-map >= 0.4.0.0
-                , dependent-sum >= 0.7.1.0
-                , dependent-sum-template >= 0.1.1.1
-                , deriving-aeson >= 0.2.8
-                , deriving-compat >= 0.6
-                , dictionary-sharing >= 0.1.0.0
-                , distributive >= 0.6.2.1
-                , dlist >= 1.0
-                , dom-lt >= 0.2.3
-                , double-conversion >= 2.0.2.0
-                , erf >= 2.0.0.0
-                , exceptions >= 0.10.4
-                , extra >= 1.7.10
-                , fin >= 0.2.1
-                , flat >= 0.4.5
-                , foldl >= 1.4.12
-                , formatting >= 7.1.3
-                , foundation >= 0.0.26.1
-                , free >= 5.1.7
-                , half >= 0.3.1
-                , hashable >= 1.4.0.2
-                , haskell-lexer >= 1.1
-                , hedgehog >= 1.0.5
-                , indexed-traversable >= 0.1.2
-                , indexed-traversable-instances >= 0.1.1
-                , integer-logarithms >= 1.0.3.1
-                , invariant >= 0.5.5
-                , kan-extensions >= 5.2.3
-                , lazy-search >= 0.1.2.1
-                , lazysmallcheck >= 0.6
-                , lens >= 5.1
-                , lifted-async >= 0.10.2.2
-                , lifted-base >= 0.2.3.12
-                , list-t >= 1.0.5.1
-                , logict >= 0.7.0.3
-                , megaparsec >= 9.2.0
-                , memory >= 0.16.0
-                , microlens >= 0.4.12.0
-                , mmorph >= 1.2.0
-                , monad-control >= 1.0.3.1
-                , mono-traversable >= 1.0.15.3
-                , monoidal-containers >= 0.6.2.0
-                , mtl-compat >= 0.2.2
-                , newtype >= 0.2.2.0
-                , newtype-generics >= 0.6.1
-                , nothunks >= 0.1.3
-                , old-locale >= 1.0.0.7
-                , old-time >= 1.1.0.3
-                , optparse-applicative >= 0.16.1.0
-                , parallel >= 3.2.2.0
-                , parser-combinators >= 1.3.0
-                , plutus-core >= 0.1.0.0
-                , plutus-ledger-api >= 0.1.0.0
-                , plutus-tx >= 0.1.0.0
-                , pretty-show >= 1.10
-                , prettyprinter >= 1.7.1
-                , prettyprinter-configurable >= 0.1.0.0
-                , primitive >= 0.7.3.0
-                , profunctors >= 5.6.2
-                , protolude >= 0.3.0
-                , quickcheck-instances >= 0.3.27
-                , ral >= 0.2.1
-                , random >= 1.2.1
-                , rank2classes >= 1.4.4
-                , recursion-schemes >= 5.2.2.2
-                , reflection >= 2.1.6
-                , resourcet >= 1.2.4.3
-                , safe >= 0.3.19
-                , safe-exceptions >= 0.1.7.2
-                , scientific >= 0.3.7.0
-                , semialign >= 1.2.0.1
-                , semigroupoids >= 5.3.7
-                , semigroups >= 0.20
-                , serialise >= 0.2.4.0
-                , size-based >= 0.1.2.0
-                , some >= 1.0.3
-                , split >= 0.2.3.4
-                , splitmix >= 0.1.0.4
-                , stm >= 2.5.0.0
-                , strict >= 0.4.0.1
-                , syb >= 0.7.2.1
-                , tagged >= 0.8.6.1
-                , tasty >= 1.4.2.1
-                , tasty-golden >= 2.3.5
-                , tasty-hedgehog >= 1.1.0.0
-                , tasty-hunit >= 0.10.0.3
-                , temporary >= 1.3
-                , terminal-size >= 0.3.2.1
-                , testing-type-modifiers >= 0.1.0.1
-                , text-short >= 0.1.5
-                , th-abstraction >= 0.4.3.0
-                , th-compat >= 0.1.3
-                , th-expand-syns >= 0.4.9.0
-                , th-extras >= 0.0.0.6
-                , th-lift >= 0.8.2
-                , th-lift-instances >= 0.1.19
-                , th-orphans >= 0.13.12
-                , th-reify-many >= 0.1.10
-                , th-utilities >= 0.2.4.3
-                , these >= 1.1.1.1
-                , time-compat >= 1.9.6.1
-                , transformers-base >= 0.4.6
-                , transformers-compat >= 0.7.1
-                , type-equality >= 1
-                , typed-process >= 0.2.8.0
-                , unbounded-delays >= 0.1.1.1
-                , universe-base >= 1.1.3
-                , unliftio-core >= 0.2.0.1
-                , unordered-containers >= 0.2.16.0
-                , uuid-types >= 1.0.5
-                , vector >= 0.12.3.1
-                , vector-algorithms >= 0.8.0.4
-                , void >= 0.7.3
-                , wcwidth >= 0.0.2
-                , witherable >= 0.4.2
-                , wl-pprint-annotated >= 0.1.0.1
-                , word-array >= 0.1.0.0
-                , secp256k1-haskell >= 0.6
-                , inline-r >= 0.10.5
-            '');
+            // (o.extra-hackage-tarballs or { });
+            cabalProjectLocal = o'.cabalProjectLocal or "" + (
+              ''
+                allow-newer:
+                  cardano-binary:base
+                  , cardano-crypto-class:base
+                  , cardano-prelude:base
+                  , canonical-json:bytestring
+                  , plutus-core:ral
+                  , plutus-core:some
+                  , int-cast:base
+                  , inline-r:singletons
+                constraints:
+                  OneTuple >= 0.3.1
+                  , Only >= 0.1
+                  , QuickCheck >= 2.14.2
+                  , StateVar >= 1.2.2
+                  , Stream >= 0.4.7.2
+                  , adjunctions >= 4.4
+                  , aeson >= 2.0.3.0
+                  , algebraic-graphs >= 0.6
+                  , ansi-terminal >= 0.11.1
+                  , ansi-wl-pprint >= 0.6.9
+                  , assoc >= 1.0.2
+                  , async >= 2.2.4
+                  , attoparsec >= 0.14.4
+                  , barbies >= 2.0.3.1
+                  , base-compat >= 0.12.1
+                  , base-compat-batteries >= 0.12.1
+                  , base-orphans >= 0.8.6
+                  , base16-bytestring >= 1.0.2.0
+                  , basement >= 0.0.12
+                  , bifunctors >= 5.5.11
+                  , bimap >= 0.4.0
+                  , bin >= 0.1.2
+                  , boring >= 0.2
+                  , boxes >= 0.1.5
+                  , cabal-doctest >= 1.0.9
+                  , call-stack >= 0.4.0
+                  , canonical-json >= 0.6.0.0
+                  , cardano-binary >= 1.5.0
+                  , cardano-crypto >= 1.1.0
+                  , cardano-crypto-class >= 2.0.0
+                  , cardano-prelude >= 0.1.0.0
+                  , case-insensitive >= 1.2.1.0
+                  , cassava >= 0.5.2.0
+                  , cborg >= 0.2.6.0
+                  , clock >= 0.8.2
+                  , colour >= 2.3.6
+                  , comonad >= 5.0.8
+                  , composition-prelude >= 3.0.0.2
+                  , concurrent-output >= 1.10.14
+                  , constraints >= 0.13.2
+                  , constraints-extras >= 0.3.2.1
+                  , contravariant >= 1.5.5
+                  , cryptonite >= 0.29
+                  , data-default >= 0.7.1.1
+                  , data-default-class >= 0.1.2.0
+                  , data-default-instances-containers >= 0.0.1
+                  , data-default-instances-dlist >= 0.0.1
+                  , data-default-instances-old-locale >= 0.0.1
+                  , data-fix >= 0.3.2
+                  , dec >= 0.0.4
+                  , dependent-map >= 0.4.0.0
+                  , dependent-sum >= 0.7.1.0
+                  , dependent-sum-template >= 0.1.1.1
+                  , deriving-aeson >= 0.2.8
+                  , deriving-compat >= 0.6
+                  , dictionary-sharing >= 0.1.0.0
+                  , distributive >= 0.6.2.1
+                  , dlist >= 1.0
+                  , dom-lt >= 0.2.3
+                  , double-conversion >= 2.0.2.0
+                  , erf >= 2.0.0.0
+                  , exceptions >= 0.10.4
+                  , extra >= 1.7.10
+                  , fin >= 0.2.1
+                  , flat >= 0.4.5
+                  , foldl >= 1.4.12
+                  , formatting >= 7.1.3
+                  , foundation >= 0.0.26.1
+                  , free >= 5.1.7
+                  , half >= 0.3.1
+                  , hashable >= 1.4.0.2
+                  , haskell-lexer >= 1.1
+                  , hedgehog >= 1.0.5
+                  , indexed-traversable >= 0.1.2
+                  , indexed-traversable-instances >= 0.1.1
+                  , integer-logarithms >= 1.0.3.1
+                  , invariant >= 0.5.5
+                  , kan-extensions >= 5.2.3
+                  , lazy-search >= 0.1.2.1
+                  , lazysmallcheck >= 0.6
+                  , lens >= 5.1
+                  , lifted-async >= 0.10.2.2
+                  , lifted-base >= 0.2.3.12
+                  , list-t >= 1.0.5.1
+                  , logict >= 0.7.0.3
+                  , megaparsec >= 9.2.0
+                  , memory >= 0.16.0
+                  , microlens >= 0.4.12.0
+                  , mmorph >= 1.2.0
+                  , monad-control >= 1.0.3.1
+                  , mono-traversable >= 1.0.15.3
+                  , monoidal-containers >= 0.6.2.0
+                  , mtl-compat >= 0.2.2
+                  , newtype >= 0.2.2.0
+                  , newtype-generics >= 0.6.1
+                  , nothunks >= 0.1.3
+                  , old-locale >= 1.0.0.7
+                  , old-time >= 1.1.0.3
+                  , optparse-applicative >= 0.16.1.0
+                  , parallel >= 3.2.2.0
+                  , parser-combinators >= 1.3.0
+                  , plutus-core >= 0.1.0.0
+                  , plutus-ledger-api >= 0.1.0.0
+                  , plutus-tx >= 0.1.0.0
+                  , pretty-show >= 1.10
+                  , prettyprinter >= 1.7.1
+                  , prettyprinter-configurable >= 0.1.0.0
+                  , primitive >= 0.7.3.0
+                  , profunctors >= 5.6.2
+                  , protolude >= 0.3.0
+                  , quickcheck-instances >= 0.3.27
+                  , ral >= 0.2.1
+                  , random >= 1.2.1
+                  , rank2classes >= 1.4.4
+                  , recursion-schemes >= 5.2.2.2
+                  , reflection >= 2.1.6
+                  , resourcet >= 1.2.4.3
+                  , safe >= 0.3.19
+                  , safe-exceptions >= 0.1.7.2
+                  , scientific >= 0.3.7.0
+                  , semialign >= 1.2.0.1
+                  , semigroupoids >= 5.3.7
+                  , semigroups >= 0.20
+                  , serialise >= 0.2.4.0
+                  , size-based >= 0.1.2.0
+                  , some >= 1.0.3
+                  , split >= 0.2.3.4
+                  , splitmix >= 0.1.0.4
+                  , stm >= 2.5.0.0
+                  , strict >= 0.4.0.1
+                  , syb >= 0.7.2.1
+                  , tagged >= 0.8.6.1
+                  , tasty >= 1.4.2.1
+                  , tasty-golden >= 2.3.5
+                  , tasty-hedgehog >= 1.1.0.0
+                  , tasty-hunit >= 0.10.0.3
+                  , temporary >= 1.3
+                  , terminal-size >= 0.3.2.1
+                  , testing-type-modifiers >= 0.1.0.1
+                  , text-short >= 0.1.5
+                  , th-abstraction >= 0.4.3.0
+                  , th-compat >= 0.1.3
+                  , th-expand-syns >= 0.4.9.0
+                  , th-extras >= 0.0.0.6
+                  , th-lift >= 0.8.2
+                  , th-lift-instances >= 0.1.19
+                  , th-orphans >= 0.13.12
+                  , th-reify-many >= 0.1.10
+                  , th-utilities >= 0.2.4.3
+                  , these >= 1.1.1.1
+                  , time-compat >= 1.9.6.1
+                  , transformers-base >= 0.4.6
+                  , transformers-compat >= 0.7.1
+                  , type-equality >= 1
+                  , typed-process >= 0.2.8.0
+                  , unbounded-delays >= 0.1.1.1
+                  , universe-base >= 1.1.3
+                  , unliftio-core >= 0.2.0.1
+                  , unordered-containers >= 0.2.16.0
+                  , uuid-types >= 1.0.5
+                  , vector >= 0.12.3.1
+                  , vector-algorithms >= 0.8.0.4
+                  , void >= 0.7.3
+                  , wcwidth >= 0.0.2
+                  , witherable >= 0.4.2
+                  , wl-pprint-annotated >= 0.1.0.1
+                  , word-array >= 0.1.0.0
+                  , secp256k1-haskell >= 0.6
+                  , inline-r >= 0.10.5
+              ''
+            );
           };
 
         hackageDeps = (super.hackageDeps or [ ]) ++ [
@@ -593,7 +629,8 @@
     # For developing _this repository_, having nixpkgs-fmt available is convenient.
     devShell = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (system:
       let pkgs = import nixpkgs { inherit system; };
-      in pkgs.mkShell {
+      in
+      pkgs.mkShell {
         name = "shell";
         buildInputs = [ pkgs.nixpkgs-fmt ];
       });


### PR DESCRIPTION
Using this overlay will essentially ensure checks is a superset of build. This is useful for hydra builds, where attributes in check will now also have the build.