### PR TITLE
make tooling in checks and shell consistent

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+### Summary of changes
+
+...
+
+### Tested on
+- [ ] [agora](https://github.com/Liqwid-Labs/agora)
+- [ ] [liqwid-plutarch-extra](https://github.com/Liqwid-Labs/liqwid-plutarch-extra)
+- [ ] [plutarch-context-builder](https://github.com/Liqwid-Labs/plutarch-context-builder)
+- [ ] ...


### PR DESCRIPTION
Previously, tooling was different versions between checks and the shell. Now those have been unified, at least partially.