### PR TITLE
Add correct help message for command groups

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2248,11 +2248,11 @@
     },
     "nixpkgs-latest": {
       "locked": {
-        "lastModified": 1669821269,
-        "narHash": "sha256-KxEFtP9NFpQN7zDwq93pGOw8eU8Dju+1qjyXxgtfHa8=",
+        "lastModified": 1669864803,
+        "narHash": "sha256-MWxYXiKvips/hynGiX1tYX4GfLgJU3PXypYwplmqWpw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "477e6a41967b9bce5e211535e3256c42b5f03730",
+        "rev": "0b23f22d473831279b74a52aced1cbed712c18c3",
         "type": "github"
       },
       "original": {

--- a/nix/onchain.nix
+++ b/nix/onchain.nix
@@ -438,7 +438,7 @@ in
               {
                 dependencies = [ nixpkgsFmt ];
                 script = ''
-                  find . -name '*.nix' -not -path './dist*/*' -not -path './haddock/*' -exec nixpkgs-fmt {} +                
+                  find . -name '*.nix' -not -path './dist*/*' -not -path './haddock/*' -exec nixpkgs-fmt {} +
                 '';
                 groups = [ "format" "precommit" ];
                 help = ''
@@ -460,10 +460,10 @@ in
                 groups = [ "format" "precommit" ];
                 help = ''
                   echo "  Runs fourmolu and cabal-fmt."
-                  echo 
+                  echo
                   echo "  fourmolu: A formatter for Haskell source code."
                   echo "  cabal-fmt: Format .cabal files preserving the original field ordering, and comments."
-                  echo 
+                  echo
                   echo "  Fourmolu is using the following Haskell extensions:"
                   echo "${builtins.concatStringsSep "\n" (builtins.map (p: "  - " + p) projectConfig.ghc.extensions)}"
                   echo
@@ -496,7 +496,7 @@ in
               {
                 dependencies = project.shell.nativeBuildInputs;
                 script = ''
-                  hoogle server --local -p 8080 >/dev/null 
+                  hoogle server --local -p 8080 >/dev/null
                 '';
                 help = ''
                   echo '  Run a hoogle server with the local packages on port 8080.'

--- a/nix/run/default.nix
+++ b/nix/run/default.nix
@@ -172,12 +172,13 @@ in
                         scripts);
                   in
                   ''${name})
-                    echo "useage nix run.#${name}"
+                    echo "usage: nix run.#${name}"
                     echo
-                    echo "\"${name}\" group runs following scripts:"
-                    echo "  ${builtins.concatStringsSep "," (builtins.attrNames scripts)}"
+                    echo "The group \"${name}\" runs the following scripts:"
+                    echo "  ${builtins.concatStringsSep ", " (builtins.attrNames scripts)}"
                     echo
-                    echo "Description of each scripts:"
+                    echo "Description of each script:"
+                    echo
                     ${builtins.concatStringsSep "\necho\n" helps}
                   ;;'';
               in

--- a/nix/run/default.nix
+++ b/nix/run/default.nix
@@ -155,6 +155,31 @@ in
                   echo
                   ${script.help}
                 ;;'';
+                renderGroupCase = name:
+                  let
+                    scripts =
+                      (lib.filterAttrs
+                        (_: p: builtins.elem name p.groups)
+                        config.run);
+                    helps =
+                      builtins.attrValues (lib.mapAttrs
+                        (n: s:
+                          ''
+                            echo "* \"${n}\""
+                            echo
+                            ${s.help}
+                          '')
+                        scripts);
+                  in
+                  ''${name})
+                    echo "useage nix run.#${name}"
+                    echo
+                    echo "\"${name}\" group runs following scripts:"
+                    echo "  ${builtins.concatStringsSep "," (builtins.attrNames scripts)}"
+                    echo
+                    echo "Description of each scripts:"
+                    ${builtins.concatStringsSep "\necho\n" helps}
+                  ;;'';
               in
               pkgs.writeShellApplication
                 {
@@ -163,6 +188,7 @@ in
                     if [ $# -eq 1 ]; then
                       case $1 in
                         ${builtins.concatStringsSep "\n" (builtins.attrValues (builtins.mapAttrs renderCase config.run))}
+                        ${builtins.concatStringsSep "\n" (builtins.map renderGroupCase (builtins.attrNames groups))}
                         *) echo "error: run script $1 not found"; exit 1 ;;
                       esac
                     else
@@ -188,4 +214,3 @@ in
       };
   };
 }
-


### PR DESCRIPTION
Added correct help messages to group help messages.

```
useage nix run.#precommit

"precommit" group runs following scripts:
  haskellFormat,haskellLint,nixFormat

Description of each scripts:
* "haskellFormat"

  Runs fourmolu and cabal-fmt.

  fourmolu: A formatter for Haskell source code.
  cabal-fmt: Format .cabal files preserving the original field ordering, and comments.

  Fourmolu is using the following Haskell extensions:
  - QuasiQuotes
  - TemplateHaskell
  - TypeApplications
  - ImportQualifiedPost
  - PatternSynonyms
  - OverloadedRecordDot

  NOTE: You can change these in the flake module!

* "haskellLint"

  hlint: HLint gives hints on how to improve Haskell code.

* "nixFormat"

  Formats nix files using nixpkgs-fmt.
```
