### PR TITLE
deprecating `haskell-nix-extra-hackage` and using `haskell.nix` tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 2.0.1 -- 2022-12-12
+
+- Vendored version of mkHackage instead of using now deprecated `haskell-nix-extra-hackage`.
+
+- `hlint` and `haskell-language-server` provided using `tools` option of haskell.nix instead
+  of manually.
+
 ## 2.0.0 -- 2022-11-28
 
 - Rework Nix system into using flake-parts.

--- a/flake.lock
+++ b/flake.lock
@@ -1186,22 +1186,6 @@
     "haskell-language-server": {
       "flake": false,
       "locked": {
-        "lastModified": 1670509556,
-        "narHash": "sha256-K9QgrKwZr/w/RrdI8bUg4yJEoUy0PjgkPuEc4+Io1AE=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "f6296524b8c65deff4fcd49fcf3af5dfe4aa253d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "haskell-language-server_2": {
-      "flake": false,
-      "locked": {
         "lastModified": 1663135728,
         "narHash": "sha256-ghyyig0GZXRXS56FxH8unpDceU06i/uGBCBmRwneZPw=",
         "owner": "haskell",
@@ -2586,7 +2570,7 @@
         "__old__pre-commit-hooks-nix": "__old__pre-commit-hooks-nix",
         "gitignore-nix": "gitignore-nix",
         "hackage-nix": "hackage-nix",
-        "haskell-language-server": "haskell-language-server_2",
+        "haskell-language-server": "haskell-language-server",
         "haskell-nix": "haskell-nix_3",
         "iohk-nix": "iohk-nix_3",
         "nixpkgs": "nixpkgs_9",
@@ -2637,7 +2621,6 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "ghc-next-packages": "ghc-next-packages",
-        "haskell-language-server": "haskell-language-server",
         "haskell-nix": "haskell-nix",
         "iohk-nix": "iohk-nix",
         "nixpkgs": [

--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1668450977,
-        "narHash": "sha256-cfLhMhnvXn6x1vPm+Jow3RiFAUSCw/l1utktCw5rVA4=",
+        "lastModified": 1670441596,
+        "narHash": "sha256-+T487QnluBT5F9tVk0chG/zzv+9zzTrx3o7rlOBK7ps=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "d591857e9d7dd9ddbfba0ea02b43b927c3c0f1fa",
+        "rev": "8d0e2444ab05f79df93b70e5e497f8c708eb6b9b",
         "type": "github"
       },
       "original": {
@@ -1186,11 +1186,11 @@
     "haskell-language-server": {
       "flake": false,
       "locked": {
-        "lastModified": 1669648791,
-        "narHash": "sha256-3RbN8CP9LXlFraW0dcEaN+5+ztU6IEqiWD9uLPdyoQ8=",
+        "lastModified": 1670509556,
+        "narHash": "sha256-K9QgrKwZr/w/RrdI8bUg4yJEoUy0PjgkPuEc4+Io1AE=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "aeb57a8eb56964c8666d7cd05b6ba46d531de7c7",
+        "rev": "f6296524b8c65deff4fcd49fcf3af5dfe4aa253d",
         "type": "github"
       },
       "original": {
@@ -1254,29 +1254,6 @@
         "owner": "input-output-hk",
         "repo": "haskell.nix",
         "rev": "cbf1e918b6e278a81c385155605b8504e498efef",
-        "type": "github"
-      }
-    },
-    "haskell-nix-extra-hackage": {
-      "inputs": {
-        "haskell-nix": [
-          "haskell-nix"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1658790167,
-        "narHash": "sha256-QRZCAz/k5hEvXiHc2aVDDc2jgPTeiRXUtARg0GA9rDU=",
-        "owner": "mlabs-haskell",
-        "repo": "haskell-nix-extra-hackage",
-        "rev": "ee50d7eb739819efdb27bda9f444e007c12e9833",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mlabs-haskell",
-        "repo": "haskell-nix-extra-hackage",
         "type": "github"
       }
     },
@@ -2232,11 +2209,11 @@
     },
     "nixpkgs-latest": {
       "locked": {
-        "lastModified": 1669864803,
-        "narHash": "sha256-MWxYXiKvips/hynGiX1tYX4GfLgJU3PXypYwplmqWpw=",
+        "lastModified": 1670722629,
+        "narHash": "sha256-1Lx1o/HgfQMthAqiPI79nE8ugjbGs54AQUASlSjlPBE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0b23f22d473831279b74a52aced1cbed712c18c3",
+        "rev": "43dcea78854e081966f03077330445d63c028c33",
         "type": "github"
       },
       "original": {
@@ -2662,7 +2639,6 @@
         "ghc-next-packages": "ghc-next-packages",
         "haskell-language-server": "haskell-language-server",
         "haskell-nix": "haskell-nix",
-        "haskell-nix-extra-hackage": "haskell-nix-extra-hackage",
         "iohk-nix": "iohk-nix",
         "nixpkgs": [
           "haskell-nix",

--- a/flake.nix
+++ b/flake.nix
@@ -18,9 +18,6 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
 
     # On-chain deps
-    haskell-nix-extra-hackage.url = "github:mlabs-haskell/haskell-nix-extra-hackage";
-    haskell-nix-extra-hackage.inputs.haskell-nix.follows = "haskell-nix";
-    haskell-nix-extra-hackage.inputs.nixpkgs.follows = "nixpkgs";
     haskell-nix.url = "github:input-output-hk/haskell.nix?rev=cbf1e918b6e278a81c385155605b8504e498efef";
     iohk-nix.url = "github:input-output-hk/iohk-nix?rev=4848df60660e21fbb3fe157d996a8bac0a9cf2d6";
     iohk-nix.flake = false;
@@ -28,8 +25,6 @@
     ghc-next-packages.url = "github:input-output-hk/ghc-next-packages?ref=repo";
     ghc-next-packages.flake = false;
 
-    haskell-language-server.url = "github:haskell/haskell-language-server";
-    haskell-language-server.flake = false;
     plutarch.url = "github:Plutonomicon/plutarch-plutus?ref=master";
   };
 

--- a/nix/mk-hackage.nix
+++ b/nix/mk-hackage.nix
@@ -1,0 +1,133 @@
+{ liqwid-nix, system, pkgs, lib, ... }:
+rec {
+  mkPackageSpec = src:
+    with lib;
+    let
+      cabalFiles = concatLists (mapAttrsToList
+        (name: type: if type == "regular" && hasSuffix ".cabal" name then [ name ] else [ ])
+        (builtins.readDir src));
+
+      cabalPath =
+        if length cabalFiles == 1
+        then src + "/${builtins.head cabalFiles}"
+        else builtins.abort "Could not find unique file with .cabal suffix in source: ${src}";
+      cabalFile = builtins.readFile cabalPath;
+      parse = field:
+        let
+          lines = filter (s: if builtins.match "^${field} *:.*$" (toLower s) != null then true else false) (splitString "\n" cabalFile);
+          line =
+            if lines != [ ]
+            then head lines
+            else builtins.abort "Could not find line with prefix ''${field}:' in ${cabalPath}";
+        in
+        replaceStrings [ " " ] [ "" ] (head (tail (splitString ":" line)));
+      pname = parse "name";
+      version = parse "version";
+    in
+    { inherit src pname version; };
+
+  mkPackageTarball = { pname, version, src }:
+    pkgs.runCommand "${pname}-${version}.tar.gz" { } ''
+      tar --sort=name --owner=Hackage:0 --group=Hackage:0 --mtime='UTC 2009-01-01' -czvf $out ${src}
+    '';
+
+  mkHackageDir = { pname, version, src }@spec:
+    pkgs.runCommand "${pname}-${version}-hackage"
+      { } ''
+      set -e
+      mkdir -p $out/${pname}/${version}
+      md5=11111111111111111111111111111111
+      sha256=1111111111111111111111111111111111111111111111111111111111111111
+      length=1
+      cat <<EOF > $out/"${pname}"/"${version}"/package.json
+      {
+        "signatures" : [],
+        "signed" : {
+            "_type" : "Targets",
+            "expires" : null,
+            "targets" : {
+              "<repo>/package/${pname}-${version}.tar.gz" : {
+                  "hashes" : {
+                    "md5" : "$md5",
+                    "sha256" : "$sha256"
+                  },
+                  "length" : $length
+              }
+            },
+            "version" : 0
+        }
+      }
+      EOF
+      cp ${src}/*.cabal $out/"${pname}"/"${version}"/
+    '';
+
+  mkHackageTarballFromDirs = hackageDirs:
+    pkgs.runCommand "01-index.tar.gz" { } ''
+      mkdir hackage
+      ${builtins.concatStringsSep "" (map (dir: ''
+        echo ${dir}
+        ln -s ${dir}/* hackage/
+      '') hackageDirs)}
+      cd hackage
+      tar --sort=name --owner=root:0 --group=root:0 --mtime='UTC 2009-01-01' -hczvf $out */*/*
+    '';
+
+  mkHackageTarball = pkg-specs:
+    mkHackageTarballFromDirs (map mkHackageDir pkg-specs);
+
+  mkHackageNix = compiler-nix-name: hackageTarball:
+    pkgs.runCommand "hackage-nix" { } ''
+      set -e
+      export LC_CTYPE=C.UTF-8
+      export LC_ALL=C.UTF-8
+      export LANG=C.UTF-8
+      cp ${hackageTarball} 01-index.tar.gz
+      ${pkgs.gzip}/bin/gunzip 01-index.tar.gz
+      ${pkgs.haskell-nix.nix-tools.${compiler-nix-name}}/bin/hackage-to-nix $out 01-index.tar "https://mkHackageNix/"
+    '';
+
+  copySrc = src: pkgs.runCommand "copied-src-${builtins.baseNameOf src}"
+    {
+      __contentAddressed = true;
+    } ''
+    cp -T -r ${src} $out
+  '';
+
+  mkModule = extraHackagePackages: {
+    # Prevent nix-build from trying to download the packages
+    packages = lib.listToAttrs (map
+      (spec: {
+        name = spec.pname;
+        value = { src = lib.mkOverride 99 (copySrc spec.src); };
+      })
+      extraHackagePackages);
+  };
+
+  mkHackageFromSpec = compiler-nix-name: extraHackagePackages: rec {
+    extra-hackage-tarball = mkHackageTarball extraHackagePackages;
+    extra-hackage = mkHackageNix compiler-nix-name extra-hackage-tarball;
+    module = mkModule extraHackagePackages;
+  };
+
+  mkHackage = compiler-nix-name: srcs:
+    let
+      # from mlabs-tooling.nix.
+      hackages = [ (mkHackageFromSpec compiler-nix-name (map mkPackageSpec srcs)) ];
+      ifd-parallel =
+        pkgs.runCommandNoCC "ifd-parallel"
+          { myInputs = builtins.foldl' (b: a: b ++ [ a.extra-hackage a.extra-hackage-tarball ]) [ ] hackages; }
+          "echo $myInputs > $out";
+      ifdseq = x: builtins.seq (builtins.readFile ifd-parallel.outPath) x;
+    in
+    {
+      modules = ifdseq (builtins.map (x: x.module) hackages);
+      extra-hackage-tarballs = ifdseq (
+        lib.listToAttrs (lib.imap0
+          (i: x: {
+            name = "_" + builtins.toString i;
+            value = x.extra-hackage-tarball;
+          })
+          hackages));
+      extra-hackages = ifdseq (builtins.map (x: import x.extra-hackage) hackages);
+    };
+}

--- a/nix/onchain.nix
+++ b/nix/onchain.nix
@@ -170,6 +170,7 @@ in
         inherit (pkgs) haskell-nix;
 
         utils = import ./utils.nix { inherit pkgs lib; };
+        hackageUtils = import ./mk-hackage.nix { inherit liqwid-nix system pkgs lib; };
         makeProject = projectName: projectConfig:
           let
 
@@ -233,7 +234,7 @@ in
             ] ++ projectConfig.extraHackageDeps;
 
             customHackages =
-              liqwid-nix.haskell-nix-extra-hackage.mkHackagesFor system
+              hackageUtils.mkHackage
                 projectConfig.ghc.version
                 hackageDeps;
 
@@ -279,30 +280,13 @@ in
               })
             ];
 
-            hls' =
-              haskell-nix.cabalProject' {
-                modules = [{
-                  inherit nonReinstallablePkgs;
-                  reinstallableLibGhc = false;
-                }];
-
-                compiler-nix-name = projectConfig.ghc.version;
-                src = "${liqwid-nix.haskell-language-server}";
-                sha256map."https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" =
-                  "fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ=";
-              };
-            hls =
-              hls'.hsPkgs.haskell-language-server.components.exes.haskell-language-server;
-
             commandLineTools =
               [
                 pkgs-latest.cabal-install
-                hlint
                 cabalFmt
                 fourmolu
                 nixpkgsFmt
                 hasktags
-                hls
                 pkgs-latest.fd
                 pkgs-latest.entr
                 applyRefact
@@ -317,6 +301,10 @@ in
                   shell = {
                     withHoogle = true;
                     exactDeps = true;
+                    tools = {
+                      hlint = { };
+                      haskell-language-server = { };
+                    };
                     nativeBuildInputs = commandLineTools;
                     shellHook = ''
                       liqwid(){ c=$1; shift; nix run .#$c -- $@; }
@@ -536,4 +524,3 @@ in
       };
   };
 }
-


### PR DESCRIPTION
### Summary of changes
mlabs-haskell/haskell-nix-extra-hackage is been achieved. This PR vendors functionalities `haskell-nix-extra-hackage` gave previously in `nix/mk-hackage.nix`. 

Additionally, it uses `haskell-language-server` from `haskell.nix`. It no longer manually builds HLS and its dependencies. (#32)

I have tested on `liqwid-plutarch-extra` and `oracle-onchain` but it doesn't seem to solve the very slow nix evaluation problem we previously had on `oracle-onchain`

### Tested on
- [ ] [agora](https://github.com/Liqwid-Labs/agora)
- [x] [liqwid-plutarch-extra](https://github.com/Liqwid-Labs/liqwid-plutarch-extra)
- [ ] [plutarch-context-builder](https://github.com/Liqwid-Labs/plutarch-context-builder)
- [ ] ...
