### PR TITLE
Make tools packages configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 2.2.0 - 2023-01-02
+
+- Add `fourmolu.package` and `applyRefact.package` options.
+- This change is breaking due to https://github.com/NixOS/nixpkgs/issues/112494
+
 ## 2.1.1 - 2022-12-26
 
 - Off-chain module requires inputs being passed by project consuming liqwid-nix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## 2.2.0 - 2023-01-02
 
-- Add `fourmolu.package` and `applyRefact.package` options.
+- Add `fourmolu.package`, `applyRefact.package`, `hlint.package`,
+  `cabalFmt.package`, and `hasktags.package` options.
 - This change is breaking due to https://github.com/NixOS/nixpkgs/issues/112494
 
 ## 2.1.1 - 2022-12-26

--- a/nix/onchain.nix
+++ b/nix/onchain.nix
@@ -70,6 +70,30 @@ in
             };
           };
 
+          hlint = types.submodule {
+            options = {
+              package = lib.mkPackageOption pkgs "hlint" {
+                default = [ "haskell" "packages" "ghc924" "hlint" ];
+              };
+            };
+          };
+
+          cabalFmt = types.submodule {
+            options = {
+              package = lib.mkPackageOption pkgs "cabal-fmt" {
+                default = [ "haskellPackages" "cabal-fmt" ];
+              };
+            };
+          };
+
+          hasktags = types.submodule {
+            options = {
+              package = lib.mkPackageOption pkgs "hasktags" {
+                default = [ "haskell" "packages" "ghc924" "hasktags" ];
+              };
+            };
+          };
+
           shell = types.submodule {
             options = {
               extraCommandLineTools = lib.mkOption {
@@ -119,6 +143,33 @@ in
                   Added in: 2.2.0
                 '';
                 type = applyRefact;
+              };
+
+              hlint = lib.mkOption {
+                description = ''
+                  HLint-related options for the on-chain build.
+
+                  Added in: 2.2.0
+                '';
+                type = hlint;
+              };
+
+              cabalFmt = lib.mkOption {
+                description = ''
+                  Cabal-fmt-related options for the on-chain build.
+
+                  Added in: 2.2.0
+                '';
+                type = cabalFmt;
+              };
+
+              hasktags = lib.mkOption {
+                description = ''
+                  Hasktags-related options for the on-chain build.
+
+                  Added in: 2.2.0
+                '';
+                type = hasktags;
               };
 
               shell = lib.mkOption {
@@ -214,10 +265,10 @@ in
 
             fourmolu = projectConfig.fourmolu.package;
             applyRefact = projectConfig.applyRefact.package;
-            hlint = pkgs.haskell.packages.ghc924.hlint;
+            hlint = projectConfig.hlint.package;
             nixpkgsFmt = pkgs.nixpkgs-fmt;
-            cabalFmt = pkgs-latest.haskellPackages.cabal-fmt;
-            hasktags = pkgs.haskell.packages.ghc924.hasktags;
+            cabalFmt = projectConfig.cabalFmt.package;
+            hasktags = projectConfig.hasktags.package;
 
             ghc = pkgs.haskell.compiler.${projectConfig.ghc.version};
 

--- a/nix/onchain.nix
+++ b/nix/onchain.nix
@@ -62,6 +62,14 @@ in
             };
           };
 
+          applyRefact = types.submodule {
+            options = {
+              package = lib.mkPackageOption pkgs "apply-refact" {
+                default = [ "haskell" "packages" "ghc924" "apply-refact_0_10_0_0" ];
+              };
+            };
+          };
+
           shell = types.submodule {
             options = {
               extraCommandLineTools = lib.mkOption {
@@ -102,6 +110,15 @@ in
                   Added in: TODO
                 '';
                 type = fourmolu;
+              };
+
+              applyRefact = lib.mkOption {
+                description = ''
+                  Apply-refact-related options for the on-chain build.
+
+                  Added in: TODO
+                '';
+                type = applyRefact;
               };
 
               shell = lib.mkOption {
@@ -196,7 +213,7 @@ in
             pkgs = import liqwid-nix.nixpkgs { inherit system; };
 
             fourmolu = projectConfig.fourmolu.package;
-            applyRefact = pkgs.haskell.packages.ghc924.apply-refact_0_10_0_0;
+            applyRefact = projectConfig.applyRefact.package;
             hlint = pkgs.haskell.packages.ghc924.hlint;
             nixpkgsFmt = pkgs.nixpkgs-fmt;
             cabalFmt = pkgs-latest.haskellPackages.cabal-fmt;

--- a/nix/onchain.nix
+++ b/nix/onchain.nix
@@ -107,7 +107,7 @@ in
                 description = ''
                   Fourmolu-related options for the on-chain build.
 
-                  Added in: TODO
+                  Added in: 2.2.0
                 '';
                 type = fourmolu;
               };
@@ -116,7 +116,7 @@ in
                 description = ''
                   Apply-refact-related options for the on-chain build.
 
-                  Added in: TODO
+                  Added in: 2.2.0
                 '';
                 type = applyRefact;
               };

--- a/nix/onchain.nix
+++ b/nix/onchain.nix
@@ -54,6 +54,14 @@ in
             };
           };
 
+          fourmolu = types.submodule {
+            options = {
+              package = lib.mkPackageOption pkgs "fourmolu" {
+                default = [ "haskell" "packages" "ghc924" "fourmolu_0_9_0_0" ];
+              };
+            };
+          };
+
           shell = types.submodule {
             options = {
               extraCommandLineTools = lib.mkOption {
@@ -85,6 +93,15 @@ in
                   Added in: 2.0.0.
                 '';
                 type = ghc;
+              };
+
+              fourmolu = lib.mkOption {
+                description = ''
+                  Fourmolu-related options for the on-chain build.
+
+                  Added in: TODO
+                '';
+                type = fourmolu;
               };
 
               shell = lib.mkOption {
@@ -178,7 +195,7 @@ in
             pkgs-latest = import liqwid-nix.nixpkgs-latest { inherit system; };
             pkgs = import liqwid-nix.nixpkgs { inherit system; };
 
-            fourmolu = pkgs-latest.haskell.packages.ghc924.fourmolu_0_9_0_0;
+            fourmolu = projectConfig.fourmolu.package;
             applyRefact = pkgs.haskell.packages.ghc924.apply-refact_0_10_0_0;
             hlint = pkgs.haskell.packages.ghc924.hlint;
             nixpkgsFmt = pkgs.nixpkgs-fmt;

--- a/templates/onchain/flake.nix
+++ b/templates/onchain/flake.nix
@@ -31,6 +31,11 @@
           onchain.default = {
             src = ./.;
             ghc.version = "ghc925";
+            fourmolu = { };
+            hlint = { };
+            cabalFmt = { };
+            hasktags = { };
+            applyRefact = { };
             shell = { };
             enableBuildChecks = true;
             extraHackageDeps = [ ];


### PR DESCRIPTION
### Summary of changes

Add `fourmolu.package` and `applyRefact.package` options. Instead of juggling nixpkgs versions to find something to match tools hardcoded version, it is possible now to specify them in config.

### Tested on
- [ ] [agora](https://github.com/Liqwid-Labs/agora)
- [ ] [liqwid-plutarch-extra](https://github.com/Liqwid-Labs/liqwid-plutarch-extra)
- [ ] [plutarch-context-builder](https://github.com/Liqwid-Labs/plutarch-context-builder)
- [x] closed source project
