### PR TITLE
add nodeModules to js-lint check

### DIFF
--- a/nix/offchain.nix
+++ b/nix/offchain.nix
@@ -413,7 +413,7 @@ in
                   projectConfig.enableFormatCheck
                   (pkgs.runCommand "formatting-check"
                     {
-                      nativeBuildInputs = commandLineTools;
+                      nativeBuildInputs = commandLineTools ++ [ project.nodeModules ];
                     }
                     ''
                       cd ${self}
@@ -428,7 +428,7 @@ in
                   projectConfig.enableJsLintCheck
                   (pkgs.runCommand "js-lint-check"
                     {
-                      nativeBuildInputs = commandLineTools;
+                      nativeBuildInputs = commandLineTools ++ [ project.nodeModules ];
                     }
                     ''
                       cd ${self}


### PR DESCRIPTION
### Summary of changes

`nodeModules` are taken into account when running the js-lint check. These are derived from the project's package.json. 

### Tested on
- [ ] [agora](https://github.com/Liqwid-Labs/agora)
- [ ] [liqwid-plutarch-extra](https://github.com/Liqwid-Labs/liqwid-plutarch-extra)
- [ ] [plutarch-context-builder](https://github.com/Liqwid-Labs/plutarch-context-builder)
- [x] plutarch-quickcheck
- [x] oracle-offchain
