### PR TITLE
Pass browserRuntime to PS bundle

### DIFF
--- a/nix/offchain.nix
+++ b/nix/offchain.nix
@@ -366,7 +366,8 @@ in
               (name: bundle: project.bundlePursProject {
                 inherit (bundle)
                   bundledModuleName
-                  webpackConfig;
+                  webpackConfig
+                  browserRuntime;
                 inherit name;
 
                 main = bundle.mainModule;


### PR DESCRIPTION
### Summary of changes

`browserRuntime` was not passed to bundle configuration

### Tested on
- [ ] [agora](https://github.com/Liqwid-Labs/agora)
- [ ] [liqwid-plutarch-extra](https://github.com/Liqwid-Labs/liqwid-plutarch-extra)
- [ ] [plutarch-context-builder](https://github.com/Liqwid-Labs/plutarch-context-builder)
- [x] oracle-offchain
