### PR TITLE
Add `shell.shellHook` and `pkgs` options to offchain module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## 2.3.0 - 2023-01-23
 
-- Added `shell.shellHook` and `pkgs` options in offchain module
+- Added `shell.shellHook`, `pkgs`, and `runtime.exposeConfig` options in offchain module
 
 ## 2.2.2 - 2023-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## 2.3.0 - 2023-01-23
 
-- Added `shell.shellHook` option in offchain module
+- Added `shell.shellHook` and `pkgs` options in offchain module
 
 ## 2.2.2 - 2023-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 2.3.0 - 2023-01-23
+
+- Added `shell.shellHook` option in offchain module
+
 ## 2.2.2 - 2023-01-16
 
 - Fixed off-chain checks.

--- a/nix/offchain.nix
+++ b/nix/offchain.nix
@@ -23,6 +23,15 @@ in
                 '';
                 default = [ ];
               };
+              shellHook = lib.mkOption {
+                type = types.lines;
+                description = ''
+                  Shell code to run when the shell is started.
+
+                  Added in: 2.3.0.
+                '';
+                default = "";
+              };
             };
           };
 
@@ -434,7 +443,8 @@ in
                     packages = commandLineTools;
                     shellHook = ''
                       liqwid(){ c=$1; shift; nix run .#$c -- $@; }
-                    '';
+                    ''
+                    + projectConfig.shell.shellHook;
                   };
                 };
               in

--- a/nix/offchain.nix
+++ b/nix/offchain.nix
@@ -175,6 +175,18 @@ in
                 type = types.attrsOf types.anything;
                 default = { };
               };
+
+              exposeConfig = lib.mkOption {
+                description = ''
+                  Whether to expose the runtime config as an attribute set in
+                  `packages`. Config is not an package so you may want to set it
+                  to false.
+
+                  Added in: 2.3.0.
+                '';
+                type = types.bool;
+                default = true;
+              };
             };
           };
 
@@ -560,9 +572,10 @@ in
             };
           in
           {
-            packages = {
-              ctl-runtime = pkgs.buildCtlRuntime ctlRuntimeConfig { };
-            } // bundles;
+            packages = bundles //
+              (if projectConfig.runtime.exposeConfig
+              then { ctl-runtime = pkgs.buildCtlRuntime ctlRuntimeConfig { }; }
+              else { });
 
             run.nixFormat =
               {

--- a/nix/offchain.nix
+++ b/nix/offchain.nix
@@ -206,6 +206,8 @@ in
                 description = ''
                   Package set to use. If specified, you must also manually apply
                   CTL overlays.
+                  
+                  Added in: 2.3.0.
                 '';
                 default = null;
                 type = types.nullOr (types.raw or types.unspecified);

--- a/nix/offchain.nix
+++ b/nix/offchain.nix
@@ -179,7 +179,7 @@ in
               exposeConfig = lib.mkOption {
                 description = ''
                   Whether to expose the runtime config as an attribute set in
-                  `packages`. Config is not an package so you may want to set it
+                  `packages`. Config is not a package so you may want to set it
                   to false.
 
                   Added in: 2.3.0.


### PR DESCRIPTION
### Summary of changes

- Added `shell.shellHook` and `pkgs` options in offchain module

Not sure if `pkgs` option is a good idea, but I need to be able to apply overlays to packages passed to `purescriptProject` and `bundlePursProject`.

### Tested on
- [ ] [agora](https://github.com/Liqwid-Labs/agora)
- [ ] [liqwid-libs](https://github.com/Liqwid-Labs/liqwid-libs)
- [ ] [oracle-offchain](https://github.com/Liqwid-Labs/oracle-offchain)
- [x] Other
