### PR TITLE
Make `packageJson` and `packageLock` required options in offchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 2.5.0 - 2023-02-22
+
+- Make `packageJson` and `packageLock` required options in offchain module. CTL docs say that "It is *highly* recommended to pass" in order to prevent unncecessary rebuilds.
+
 ## 2.4.0 - 2023-02-17
 
 - Default `exposeConfig` to `false` in offchain module

--- a/nix/offchain.nix
+++ b/nix/offchain.nix
@@ -214,6 +214,24 @@ in
                 type = types.path;
               };
 
+              packageJson = lib.mkOption {
+                description = ''
+                  Path to the project's package.json file.
+
+                  Added in: 2.5.0.
+                '';
+                type = types.path;
+              };
+
+              packageLock = lib.mkOption {
+                description = ''
+                  Path to the project's package-lock.json file.
+
+                  Added in: 2.5.0.
+                '';
+                type = types.path;
+              };
+
               pkgs = lib.mkOption {
                 description = ''
                   Package set to use. If specified, you must also manually apply
@@ -561,14 +579,11 @@ in
             project =
               let
                 pkgSet = pkgs.purescriptProject {
-                  inherit (projectConfig) src;
+                  inherit (projectConfig) src packageJson packageLock;
 
                   inherit projectName pkgs;
 
                   nodejs = nodejsPackage;
-
-                  packageJson = projectConfig.src + "/package.json";
-                  packageLock = projectConfig.src + "/package-lock.json";
 
                   censorCodes = projectConfig.ignoredWarningCodes;
 


### PR DESCRIPTION
### Summary of changes

To adapt this breaking change add

```nix
packageJson = ./package.json;
packageLock = ./package-lock.json;
```

Below your `src` attribute. This way nix gets hash of lock files directly instead of whole `src`, which prevents rebuilds of NPM package set if it didn't change.

DO NOT set it to `"${src}/package.json"` as it defeats the purpose

BTW, I didn't ran formatter as code is not formatted on master and didn't want to pollute the diff

### Tested on
- [ ] [agora](https://github.com/Liqwid-Labs/agora)
- [ ] [liqwid-libs](https://github.com/Liqwid-Labs/liqwid-libs)
- [ ] [oracle-offchain](https://github.com/Liqwid-Labs/oracle-offchain)
- [ ] ...
