### PR TITLE
Using `herculesCI` instead of `flake.herculesCI`

### DIFF
--- a/nix/ci-config.nix
+++ b/nix/ci-config.nix
@@ -70,13 +70,11 @@ in
     # NOTE(Emily, 22 Mar 2023): Here we provide sensible defaults for working with liqwid-nix. 
     # These can be overwritten by the user, though. In the future, we may want some out-of-the-
     # -box implementation for enabling this somehow.
-    flake = { ... }: {
+    herculesCI = {
       # Added in: 2.7.2.
-      config.herculesCI = {
-        ciSystems = [ "x86_64-linux" ];
-        onPush.default.outputs = self.checks.x86_64-linux;
-        onPush.required.outputs = self.checks.x86_64-linux.required;
-      };
+      ciSystems = [ "x86_64-linux" ];
+      onPush.default.outputs = self.checks.x86_64-linux;
+      onPush.required.outputs = self.checks.x86_64-linux.required;
     };
     perSystem = { config, self', inputs', pkgs, system, ... }:
       let


### PR DESCRIPTION
### Summary of changes

Using `herculesCI` instead of `flake.herculesCI`. Otherwise when evaluating the `flake-parts` module defined in this flake composed together with another module that tries to define `herculesCI` I get a merging error.

```
error: The option `flake.herculesCI' is defined multiple times while it's expected to be unique.

       Definition values:
       - In `/nix/store/3abyf4ib751b5vcpgj39qamwwcc3jh59-source/nix/ci-config.nix':
           {
             ciSystems = [
               "x86_64-linux"
             ];
             onPush = {
           ...
       - In `/nix/store/dh0ddqxgdq2v63mdz4yj1hsgim3yah1m-source/flake-modules/herculesCI-attribute.nix': <function, args: {herculesCI?, primaryRepo?}>
       Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
(use '--show-trace' to show detailed location information)
```

### Tested on
- [ ] [agora](https://github.com/Liqwid-Labs/agora)
- [ ] [liqwid-libs](https://github.com/Liqwid-Labs/liqwid-libs)
- [ ] [oracle-offchain](https://github.com/Liqwid-Labs/oracle-offchain)
- [ ] ...
