### PR TITLE
deprecate ctl-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 ## Unreleased
 
 - Update templates.
+- Deprecate ctl-server.
 
 ## 2.9.2 - 2023-06-14
 


### PR DESCRIPTION
### Summary of changes

ctl-server has long been deprecated. This PR removes it from liqwid-nix.

### Tested on
- [ ] [agora](https://github.com/Liqwid-Labs/agora)
- [x] [agora-offchain](https://github.com/Liqwid-Labs/agora-offchain)
- [ ] [liqwid-libs](https://github.com/Liqwid-Labs/liqwid-libs)
- [ ] [oracle-offchain](https://github.com/Liqwid-Labs/oracle-offchain)
- [ ] ...
