### PR TITLE
Make it work with the latest CTL

### DIFF
--- a/nix/offchain.nix
+++ b/nix/offchain.nix
@@ -677,7 +677,9 @@ in
             check = utils.combineChecks "combined-checks" checks;
 
             apps = {
-              docs = project.launchSearchablePursDocs { };
+	      # TODO uncomment if re-implemented upstream
+	      # https://github.com/Plutonomicon/cardano-transaction-lib/issues/1578
+              # docs = project.launchSearchablePursDocs { };
             };
 
             devShell = project.devShell;

--- a/nix/offchain.nix
+++ b/nix/offchain.nix
@@ -502,11 +502,7 @@ in
 
                   nodejs = nodejsPackage;
 
-                  censorCodes = projectConfig.ignoredWarningCodes;
-
                   spagoPackages = fixedSpagoPackages;
-
-                  strictComp = projectConfig.compileStrict;
 
                   shell = {
                     withRuntime = true;
@@ -523,6 +519,11 @@ in
               in
               pkgSet;
 
+            builtProject = lib.makeOverridable project.buildPursProject {
+              strictComp = projectConfig.compileStrict;
+              censorCodes = projectConfig.ignoredWarningCodes;
+            };
+
             bundles = (lib.mapAttrs
               (name: bundle: project.bundlePursProject {
                 inherit (bundle)
@@ -534,6 +535,10 @@ in
 
                 main = bundle.mainModule;
                 entrypoint = bundle.entrypointJs;
+
+                builtProject = builtProject.override {
+                  main = bundle.mainModule;
+                };
               })
               projectConfig.bundles);
 
@@ -557,6 +562,7 @@ in
                         sources
                         buildInputs
                         testMain;
+                      inherit builtProject;
                     });
                 }
               else
@@ -571,6 +577,7 @@ in
                         sources
                         buildInputs
                         testMain;
+                      inherit builtProject;
                     });
                 }
               else


### PR DESCRIPTION
### Summary of changes
[This CTL commit](https://github.com/Plutonomicon/cardano-transaction-lib/commit/5072d03a466cd610bfafd09656c5233ec6f2db5b) changed a bit the Nix machinery to build purescript projects.
In particular where to pass `censorCodes` and `strictComp` and disable `launchSearchablePursDocs` (check [this issue](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1578))

The project we need this for only uses `plutipCheck` so I cannot assure that this is complete.

@emiflake @errfrom
...

### Tested on
- [ ] [agora](https://github.com/Liqwid-Labs/agora)
- [ ] [liqwid-libs](https://github.com/Liqwid-Labs/liqwid-libs)
- [ ] [oracle-offchain](https://github.com/Liqwid-Labs/oracle-offchain)
- [ ] ...
